### PR TITLE
yapf formatting pre-commit hook

### DIFF
--- a/tmp.py
+++ b/tmp.py
@@ -5,6 +5,7 @@ import torch
 
 def a(  b):
 	print(b )
+   print(     b)   
 
 
 

--- a/tmp.py
+++ b/tmp.py
@@ -1,17 +1,10 @@
-
-
 import torch
 
 
-def a(  b):
-	print(b )
-   print(     b)   
-
+def a(b):
+    print(b)
+    print(b)
 
 
 if __name__ == '__main__':
-	a('test')
-
-
-
-
+    a('test')

--- a/tmp.py
+++ b/tmp.py
@@ -1,0 +1,16 @@
+
+
+import torch
+
+
+def a(  b):
+	print(b )
+
+
+
+if __name__ == '__main__':
+	a('test')
+
+
+
+

--- a/tmp.py
+++ b/tmp.py
@@ -4,6 +4,9 @@ import torch
 def a(b):
     print(b)
     print(b)
+    print("adkalfkal")
+
+    print("adfaosdfjasdlkfjaldsjfalkdj" + "adjfaisdjf")
 
 
 if __name__ == '__main__':

--- a/tools/pre-commit.sh
+++ b/tools/pre-commit.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+
+# Git pre-commit hook to check staged Python files for formatting issues with
+# yapf.
+#
+# INSTALLING: Copy this script into `.git/hooks/pre-commit`, and mark it as
+# executable.
+#
+# This requires that yapf is installed and runnable in the environment running
+# the pre-commit hook.
+#
+# When running, this first checks for unstaged changes to staged files, and if
+# there are any, it will exit with an error. Files with unstaged changes will be
+# printed.
+#
+# If all staged files have no unstaged changes, it will run yapf against them,
+# leaving the formatting changes unstaged. Changed files will be printed.
+#
+# BUGS: This does not leave staged changes alone when used with the -a flag to
+# git commit, due to the fact that git stages ALL unstaged files when that flag
+# is used.
+
+# Find all staged Python files, and exit early if there aren't any.
+PYTHON_FILES=()
+while IFS=$'\n' read -r line; do PYTHON_FILES+=("$line"); done \
+  < <(git diff --name-only --cached --diff-filter=AM | grep --color=never '.py$')
+if [ ${#PYTHON_FILES[@]} -eq 0 ]; then
+  exit 0
+fi
+
+########## PIP VERSION #############
+# Verify that yapf is installed; if not, warn and exit.
+if ! command -v yapf >/dev/null; then
+  echo 'yapf not on path; can not format. Please install yapf:'
+  echo '    pip install yapf'
+  exit 2
+fi
+######### END PIP VERSION ##########
+
+########## PIPENV VERSION ##########
+# if ! pipenv run yapf --version 2>/dev/null 2>&1; then
+#   echo 'yapf not on path; can not format. Please install yapf:'
+#   echo '    pipenv install yapf'
+#   exit 2
+# fi
+###### END PIPENV VERSION ##########
+
+
+# Check for unstaged changes to files in the index.
+CHANGED_FILES=()
+while IFS=$'\n' read -r line; do CHANGED_FILES+=("$line"); done \
+  < <(git diff --name-only "${PYTHON_FILES[@]}")
+if [ ${#CHANGED_FILES[@]} -gt 0 ]; then
+  echo 'You have unstaged changes to some files in your commit; skipping '
+  echo 'auto-format. Please stage, stash, or revert these changes. You may '
+  echo 'find `git stash -k` helpful here.'
+  echo 'Files with unstaged changes:' "${CHANGED_FILES[@]}"
+  exit 1
+fi
+
+# Format all staged files, then exit with an error code if any have uncommitted
+# changes.
+echo 'Formatting staged Python files . . .'
+
+########## PIP VERSION #############
+yapf -i -r "${PYTHON_FILES[@]}"
+######### END PIP VERSION ##########
+
+########## PIPENV VERSION ##########
+# pipenv run yapf -i -r "${PYTHON_FILES[@]}"
+###### END PIPENV VERSION ##########
+
+
+CHANGED_FILES=()
+while IFS=$'\n' read -r line; do CHANGED_FILES+=("$line"); done \
+  < <(git diff --name-only "${PYTHON_FILES[@]}")
+if [ ${#CHANGED_FILES[@]} -gt 0 ]; then
+  echo 'Reformatted staged files. Please review and stage the changes.'
+  echo 'Files updated: ' "${CHANGED_FILES[@]}"
+  exit 1
+else
+  exit 0
+fi

--- a/tools/pre-commit.sh
+++ b/tools/pre-commit.sh
@@ -63,7 +63,7 @@ fi
 echo 'Formatting staged Python files . . .'
 
 ########## PIP VERSION #############
-yapf -i -r "${PYTHON_FILES[@]}"
+yapf -i -r "${PYTHON_FILES[@]}" || { echo 'yapf failed' ; exit 1; }
 ######### END PIP VERSION ##########
 
 ########## PIPENV VERSION ##########


### PR DESCRIPTION
Note for the first PRs: PR should be **merged by the author** after approval, don't merge a PR if it is not yours, as the author may want to still do some tweaks (and maybe even request another review if those are major).

This commit adds support for local pre-commit automatic formatting.
Once you try to commit, yapf will check code quality and **modify inplace** files that are not compliant with the formatting rules. You will have to review the changes and include them in the commit.

You can bypass the hook by adding a flag: `git commit --no-verify`.

https://github.com/google/yapf/blob/master/plugins/pre-commit.sh

In order to add yapf pre-commit formatting, execute the following locally:

```bash
conda install yapf==0.28.0
cp tools/pre-commit.sh .git/hooks/pre-commit
```

Notes:
* tmp.py had terrible formatting before I tried to commit. yapf fixes it to current form
* I don't like that empty line at the end of file is missing, but that's minor. Is this PEP8?
* If the repo is not going to be huge, we can just create a **pre-push hook** simply trying to yapf-format all the python files.

TODO:
- [ ] remove tmp.py file